### PR TITLE
Add support for Linux/Wayland with wl-paste

### DIFF
--- a/res/linux.sh
+++ b/res/linux.sh
@@ -1,14 +1,79 @@
 #!/bin/sh
 
-# require xclip(see http://stackoverflow.com/questions/592620/check-if-a-program-exists-from-a-bash-script/677212#677212)
-command -v xclip >/dev/null 2>&1 || { echo >&1 "no xclip"; exit 1; }
+# Paste an image from the display system's clipboard to a file for use in Dendron
+#
+# This script attempts to determine if X11/Xorg or Wayland are in use, and utilize an
+# appropriate/common command-line utility for each to interact with the clipboard.
 
-# write image in clipboard to file (see http://unix.stackexchange.com/questions/145131/copy-image-from-clipboard-to-file)
-if
-xclip -selection clipboard -target image/png -o >/dev/null 2>&1
-then
-xclip -selection clipboard -target image/png -o >$1 2>/dev/null
-echo $1
-else
-echo "no image"
-fi
+cleanup_bad_image_write() {
+  # Check if the file exists
+  if [ -r "${1}" ] ; then
+    # Check if the file is larger than 0 bytes, if not, it was probably a write from a command's
+    # redirect that had an error - delete it
+    if ! [ -s "${1}" ] ; then
+      rm -f "${1}"
+    fi
+  fi
+}
+
+paste_xclip() {
+  # require xclip (see http://stackoverflow.com/questions/592620/check-if-a-program-exists-from-a-bash-script/677212#677212)
+  if ! command -v xclip >/dev/null 2>&1 ; then
+    echo "no xclip"
+    exit 1
+  fi
+
+  # write image in clipboard to file (see http://unix.stackexchange.com/questions/145131/copy-image-from-clipboard-to-file)
+  if xclip -selection clipboard -target image/png -o > "${1}" 2>/dev/null ; then
+    echo "${1}"
+    exit 0
+  else
+    echo "no image"
+    cleanup_bad_image_write "${1}"
+    exit 1
+  fi
+}
+
+paste_wlclipboard() {
+  # require wl-paste from the wl-clipboard package
+  if ! command -v wl-paste >/dev/null 2>&1 ; then
+    echo "no wl-paste"
+    exit 1
+  fi
+
+  # write image in clipboard to file
+  if wl-paste --type image/png > "${1}" 2>/dev/null; then
+    echo "${1}"
+    exit 0
+  else
+    echo "no image"
+    cleanup_bad_image_write "${1}"
+    exit 1
+  fi
+}
+
+main() {
+  # Determine the Linux display type (X11, Wayland, etc)
+  # https://unix.stackexchange.com/questions/202891/how-to-know-whether-wayland-or-x11-is-being-used#comment1133584_371164
+  if command -v loginctl >/dev/null 2>&1 ; then
+    display_type="$(loginctl show-session $(loginctl show-user ${USER} -p Display --value) -p Type --value)"
+  else
+    echo "no loginctl command present, unable to determine display type - default will assume X11/Xorg" >&2
+  fi
+
+  case "${display_type}" in
+    wayland)
+      paste_wlclipboard "${1}"
+      ;;
+    x11)
+      paste_xclip "${1}"
+      ;;
+    *)
+      # To maintain backwards compatabiltiy after adding Wayland suport, assume
+      # any unknown display type uses xclip
+      paste_xclip "${1}"
+      ;;
+  esac
+}
+
+main "$@"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -352,7 +352,10 @@ class Paster {
             ascript.stdout.on('data', function (data: Buffer) {
                 let result = data.toString().trim();
                 if (result == "no xclip") {
-                    Logger.showInformationMessage('You need to install xclip command first.');
+                    Logger.showInformationMessage('You need to install the xclip command first.');
+                    return;
+                } else if (result == "no wl-paste") {
+                    Logger.showInformationMessage('You need to install the wl-paste command first.');
                     return;
                 }
                 cb(imagePath, result);


### PR DESCRIPTION
## Changes

This modifies linux.sh to support Wayland systems that do not use the
xclip command.

Logic is added to attempt to determine the type of display in use
(X11/Xorg or Wayland), and based on that, try the common clipboard CLI
commands for the given display system.

Failing to determine the display system for any reason will fall back to
the original behavior that assumes xclip is present.

This change also resulted in refactoring the script a bit since it got a
bit more complicated, any style changes are in-line with the Google
shell style guide (https://google.github.io/styleguide/shellguide.html)

A minor change to extension.ts was also made to support the error case
of wl-paste note being present on Wayland systems.

## Related issues

This change should resolve https://github.com/dendronhq/dendron/issues/1095 - which I perhaps should have filed in this repo :)

## Testing
I have tested the linux.sh script and it behaves as expected, but I have not tested this end-to-end as a VS Code extension, as I'm just not familiar with extension development yet. So hopefully it's good there, but please do test that before merging!